### PR TITLE
[#4] feat(i18n): add i18n support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,12 @@
       "dependencies": {
         "cron-parser": "^4.8.0",
         "date-fns": "^2.30.0",
+        "i18next": "^25.4.2",
+        "i18next-browser-languagedetector": "^8.2.0",
         "lucide-react": "^0.263.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-i18next": "^15.7.3",
         "react-router-dom": "^6.8.1",
         "recharts": "^2.7.2"
       },
@@ -9036,6 +9039,15 @@
       "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
       "dev": true
     },
+    "node_modules/html-parse-stringify": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
+      "integrity": "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==",
+      "license": "MIT",
+      "dependencies": {
+        "void-elements": "3.1.0"
+      }
+    },
     "node_modules/html-tags": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.3.1.tgz",
@@ -9084,6 +9096,46 @@
       "dev": true,
       "engines": {
         "node": ">=10.17.0"
+      }
+    },
+    "node_modules/i18next": {
+      "version": "25.4.2",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-25.4.2.tgz",
+      "integrity": "sha512-gD4T25a6ovNXsfXY1TwHXXXLnD/K2t99jyYMCSimSCBnBRJVQr5j+VAaU83RJCPzrTGhVQ6dqIga66xO2rtd5g==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://locize.com"
+        },
+        {
+          "type": "individual",
+          "url": "https://locize.com/i18next.html"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.27.6"
+      },
+      "peerDependencies": {
+        "typescript": "^5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/i18next-browser-languagedetector": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/i18next-browser-languagedetector/-/i18next-browser-languagedetector-8.2.0.tgz",
+      "integrity": "sha512-P+3zEKLnOF0qmiesW383vsLdtQVyKtCNA9cjSoKCppTKPQVfKd2W8hbVo5ZhNJKDqeM7BOcvNoKJOjpHh4Js9g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.23.2"
       }
     },
     "node_modules/iconv-lite": {
@@ -11717,6 +11769,32 @@
       "integrity": "sha512-Fl7FuabXsJnV5Q1qIOQwx/sagGF18kogb4gpfcG4gjLBWO0WDiiz1ko/ExayuxE7InyQkBLkxRFG5oxY6Uu3Kg==",
       "dev": true
     },
+    "node_modules/react-i18next": {
+      "version": "15.7.3",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-15.7.3.tgz",
+      "integrity": "sha512-AANws4tOE+QSq/IeMF/ncoHlMNZaVLxpa5uUGW1wjike68elVYr0018L9xYoqBr1OFO7G7boDPrbn0HpMCJxTw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.27.6",
+        "html-parse-stringify": "^3.0.1"
+      },
+      "peerDependencies": {
+        "i18next": ">= 25.4.1",
+        "react": ">= 16.8.0",
+        "typescript": "^5"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
@@ -13429,7 +13507,7 @@
       "version": "5.9.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
-      "dev": true,
+      "devOptional": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -13835,6 +13913,15 @@
         "terser": {
           "optional": true
         }
+      }
+    },
+    "node_modules/void-elements": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
+      "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/walker": {

--- a/package.json
+++ b/package.json
@@ -15,9 +15,12 @@
   "dependencies": {
     "cron-parser": "^4.8.0",
     "date-fns": "^2.30.0",
+    "i18next": "^25.4.2",
+    "i18next-browser-languagedetector": "^8.2.0",
     "lucide-react": "^0.263.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-i18next": "^15.7.3",
     "react-router-dom": "^6.8.1",
     "recharts": "^2.7.2"
   },

--- a/src/components/common/LanguageSelector.tsx
+++ b/src/components/common/LanguageSelector.tsx
@@ -1,0 +1,80 @@
+import React, { useState, useRef, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Globe } from 'lucide-react';
+
+interface Language {
+  code: string;
+  name: string;
+  flag: string;
+}
+
+const languages: Language[] = [
+  { code: 'ko', name: '한국어', flag: '🇰🇷' },
+  { code: 'en', name: 'English', flag: '🇺🇸' },
+];
+
+const LanguageSelector: React.FC = () => {
+  const { i18n } = useTranslation();
+  const [isOpen, setIsOpen] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  const currentLanguage = languages.find(lang => lang.code === i18n.language) || languages[0];
+
+  const changeLanguage = (languageCode: string) => {
+    i18n.changeLanguage(languageCode);
+    setIsOpen(false);
+  };
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, []);
+
+  return (
+    <div className="relative" ref={dropdownRef}>
+      <button
+        onClick={() => setIsOpen(!isOpen)}
+        className="flex items-center space-x-2 px-3 py-2 text-sm text-gray-700 hover:text-primary-600 hover:bg-gray-50 rounded-md transition-colors duration-200"
+        aria-label="언어 선택"
+      >
+        <Globe className="w-4 h-4" />
+        <span className="hidden sm:inline">{currentLanguage.flag}</span>
+        <span className="hidden md:inline">{currentLanguage.name}</span>
+      </button>
+
+      {isOpen && (
+        <div className="absolute right-0 mt-2 w-48 bg-white rounded-md shadow-lg border border-gray-200 z-50">
+          <div className="py-1">
+            {languages.map((language) => (
+              <button
+                key={language.code}
+                onClick={() => changeLanguage(language.code)}
+                className={`w-full text-left px-4 py-2 text-sm transition-colors duration-200 flex items-center space-x-3 ${
+                  currentLanguage.code === language.code
+                    ? 'bg-primary-50 text-primary-600'
+                    : 'text-gray-700 hover:bg-gray-50'
+                }`}
+              >
+                <span>{language.flag}</span>
+                <span>{language.name}</span>
+                {currentLanguage.code === language.code && (
+                  <span className="ml-auto text-primary-600">✓</span>
+                )}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default LanguageSelector;

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -1,7 +1,10 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
 
 const Footer: React.FC = () => {
+  const { t } = useTranslation();
+  
   return (
     <footer className="bg-white border-t border-gray-200">
       <div className="max-w-7xl mx-auto py-8 px-4 sm:px-6 lg:px-8">
@@ -12,33 +15,32 @@ const Footer: React.FC = () => {
               <div className="w-8 h-8 bg-primary-600 rounded-lg flex items-center justify-center">
                 <span className="text-white font-bold text-lg">B</span>
               </div>
-              <span className="text-xl font-bold text-gray-900">바리바리</span>
+              <span className="text-xl font-bold text-gray-900">{t('header.brand')}</span>
             </div>
             <p className="text-gray-600 text-sm">
-              다양한 변환/도구 기능을 제공하는 웹 유틸리티 허브입니다.
-              개발자와 일반 사용자를 위한 편리한 도구들을 제공합니다.
+              {t('footer.description')}
             </p>
           </div>
 
           {/* Quick Links */}
           <div>
             <h3 className="text-sm font-semibold text-gray-900 tracking-wider uppercase mb-4">
-              빠른 링크
+              {t('footer.quick_links')}
             </h3>
             <ul className="space-y-2">
               <li>
                 <Link to="/" className="text-gray-600 hover:text-primary-600 text-sm transition-colors duration-200">
-                  홈
+                  {t('common.home')}
                 </Link>
               </li>
               <li>
                 <Link to="/tools" className="text-gray-600 hover:text-primary-600 text-sm transition-colors duration-200">
-                  도구
+                  {t('common.tools')}
                 </Link>
               </li>
               <li>
                 <Link to="/dashboard" className="text-gray-600 hover:text-primary-600 text-sm transition-colors duration-200">
-                  대시보드
+                  {t('common.dashboard')}
                 </Link>
               </li>
             </ul>
@@ -47,22 +49,22 @@ const Footer: React.FC = () => {
           {/* Support */}
           <div>
             <h3 className="text-sm font-semibold text-gray-900 tracking-wider uppercase mb-4">
-              지원
+              {t('footer.support')}
             </h3>
             <ul className="space-y-2">
               <li>
                 <a href="#" className="text-gray-600 hover:text-primary-600 text-sm transition-colors duration-200">
-                  도움말
+                  {t('footer.help')}
                 </a>
               </li>
               <li>
                 <a href="#" className="text-gray-600 hover:text-primary-600 text-sm transition-colors duration-200">
-                  문의하기
+                  {t('footer.contact')}
                 </a>
               </li>
               <li>
                 <a href="#" className="text-gray-600 hover:text-primary-600 text-sm transition-colors duration-200">
-                  피드백
+                  {t('footer.feedback')}
                 </a>
               </li>
             </ul>
@@ -72,14 +74,14 @@ const Footer: React.FC = () => {
         <div className="mt-8 pt-8 border-t border-gray-200">
           <div className="flex flex-col md:flex-row justify-between items-center">
             <p className="text-gray-500 text-sm">
-              © 2024 바리바리. devgraft 팀에서 제작되었습니다.
+              {t('footer.copyright')}
             </p>
             <div className="flex space-x-6 mt-4 md:mt-0">
               <a href="#" className="text-gray-400 hover:text-gray-500 text-sm">
-                개인정보처리방침
+                {t('footer.links.privacy')}
               </a>
               <a href="#" className="text-gray-400 hover:text-gray-500 text-sm">
-                이용약관
+                {t('footer.links.terms')}
               </a>
             </div>
           </div>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,16 +1,19 @@
 import React, { useState } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import { Menu, X, User, LogIn } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import LanguageSelector from '../common/LanguageSelector';
 
 const Header: React.FC = () => {
+  const { t } = useTranslation();
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const location = useLocation();
   const isLoggedIn = false; // TODO: 실제 인증 상태로 교체
 
   const navigation = [
-    { name: '홈', href: '/' },
-    { name: '도구', href: '/tools' },
-    { name: '대시보드', href: '/dashboard' },
+    { name: t('header.navigation.home'), href: '/' },
+    { name: t('header.navigation.tools'), href: '/tools' },
+    { name: t('header.navigation.dashboard'), href: '/dashboard' },
   ];
 
   const isActive = (path: string) => location.pathname === path;
@@ -25,7 +28,7 @@ const Header: React.FC = () => {
               <div className="w-8 h-8 bg-primary-600 rounded-lg flex items-center justify-center">
                 <span className="text-white font-bold text-lg">B</span>
               </div>
-              <span className="text-xl font-bold text-gray-900">바리바리</span>
+              <span className="text-xl font-bold text-gray-900">{t('header.brand')}</span>
             </Link>
           </div>
 
@@ -48,13 +51,14 @@ const Header: React.FC = () => {
 
           {/* Auth Section */}
           <div className="flex items-center space-x-4">
+            <LanguageSelector />
             {isLoggedIn ? (
               <Link
                 to="/dashboard"
                 className="flex items-center space-x-2 text-gray-700 hover:text-primary-600 transition-colors duration-200"
               >
                 <User className="w-5 h-5" />
-                <span className="hidden sm:inline">대시보드</span>
+                <span className="hidden sm:inline">{t('header.auth.dashboard')}</span>
               </Link>
             ) : (
               <Link
@@ -62,7 +66,7 @@ const Header: React.FC = () => {
                 className="btn-primary flex items-center space-x-2"
               >
                 <LogIn className="w-4 h-4" />
-                <span>로그인</span>
+                <span>{t('header.auth.login')}</span>
               </Link>
             )}
 

--- a/src/components/tools/Base64Converter.tsx
+++ b/src/components/tools/Base64Converter.tsx
@@ -1,11 +1,13 @@
 import React, { useState } from 'react';
 import { Copy, Check, RotateCcw } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 
 interface Base64ConverterProps {
   className?: string;
 }
 
 const Base64Converter: React.FC<Base64ConverterProps> = ({ className = '' }) => {
+  const { t } = useTranslation();
   const [inputText, setInputText] = useState('');
   const [outputText, setOutputText] = useState('');
   const [mode, setMode] = useState<'encode' | 'decode'>('encode');
@@ -76,16 +78,16 @@ const Base64Converter: React.FC<Base64ConverterProps> = ({ className = '' }) => 
       {/* Header */}
       <div className="flex items-center justify-between mb-6">
         <div>
-          <h2 className="text-2xl font-bold text-gray-900 mb-2">Base64 변환기</h2>
+          <h2 className="text-2xl font-bold text-gray-900 mb-2">{t('tools.base64.title')}</h2>
           <p className="text-gray-600">
-            문자열과 Base64 간의 상호 변환을 지원합니다
+            {t('tools.base64.description')}
           </p>
         </div>
         <div className="flex items-center space-x-2">
           <button
             onClick={handleClear}
             className="p-2 text-gray-500 hover:text-gray-700 hover:bg-gray-100 rounded-lg transition-colors"
-            title="모두 지우기"
+            title={t('common.delete')}
           >
             <RotateCcw className="w-5 h-5" />
           </button>
@@ -102,7 +104,7 @@ const Base64Converter: React.FC<Base64ConverterProps> = ({ className = '' }) => 
               : 'text-gray-600 hover:text-gray-900'
           }`}
         >
-          문자열 → Base64
+          {t('tools.base64.encode')}
         </button>
         <button
           onClick={() => handleModeChange('decode')}
@@ -112,31 +114,27 @@ const Base64Converter: React.FC<Base64ConverterProps> = ({ className = '' }) => 
               : 'text-gray-600 hover:text-gray-900'
           }`}
         >
-          Base64 → 문자열
+          {t('tools.base64.decode')}
         </button>
       </div>
 
       {/* Input Section */}
       <div className="mb-6">
         <label className="block text-sm font-medium text-gray-700 mb-2">
-          {mode === 'encode' ? '입력 문자열' : 'Base64 문자열'}
+          {mode === 'encode' ? t('tools.base64.input_placeholder') : 'Base64'}
         </label>
         <div className="relative">
           <textarea
             value={inputText}
             onChange={handleInputChange}
-            placeholder={
-              mode === 'encode'
-                ? '변환할 문자열을 입력하세요...'
-                : '변환할 Base64 문자열을 입력하세요...'
-            }
+            placeholder={t('tools.base64.input_placeholder')}
             className="w-full h-32 px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent resize-none"
           />
           {inputText && (
             <button
               onClick={() => handleCopy(inputText)}
               className="absolute top-2 right-2 p-2 text-gray-500 hover:text-gray-700 hover:bg-gray-100 rounded-lg transition-colors"
-              title="입력 텍스트 복사"
+              title={t('common.save')}
             >
               {copied ? <Check className="w-4 h-4 text-green-600" /> : <Copy className="w-4 h-4" />}
             </button>
@@ -152,7 +150,7 @@ const Base64Converter: React.FC<Base64ConverterProps> = ({ className = '' }) => 
             className="flex items-center space-x-2 px-4 py-2 bg-primary-100 text-primary-700 rounded-lg hover:bg-primary-200 transition-colors"
           >
             <RotateCcw className="w-4 h-4" />
-            <span>입출력 바꾸기</span>
+            <span>{t('common.update')}</span>
           </button>
         </div>
       )}
@@ -160,17 +158,13 @@ const Base64Converter: React.FC<Base64ConverterProps> = ({ className = '' }) => 
       {/* Output Section */}
       <div className="mb-6">
         <label className="block text-sm font-medium text-gray-700 mb-2">
-          {mode === 'encode' ? 'Base64 결과' : '문자열 결과'}
+          {mode === 'encode' ? 'Base64' : t('tools.base64.output_placeholder')}
         </label>
         <div className="relative">
           <textarea
             value={outputText}
             readOnly
-            placeholder={
-              mode === 'encode'
-                ? 'Base64로 변환된 결과가 여기에 표시됩니다'
-                : '문자열로 변환된 결과가 여기에 표시됩니다'
-            }
+            placeholder={t('tools.base64.output_placeholder')}
             className={`w-full h-32 px-4 py-3 border rounded-lg resize-none ${
               error
                 ? 'border-red-300 bg-red-50 text-red-700'
@@ -181,7 +175,7 @@ const Base64Converter: React.FC<Base64ConverterProps> = ({ className = '' }) => 
             <button
               onClick={() => handleCopy(outputText)}
               className="absolute top-2 right-2 p-2 text-gray-500 hover:text-gray-700 hover:bg-gray-100 rounded-lg transition-colors"
-              title="결과 텍스트 복사"
+              title={t('common.save')}
             >
               {copied ? <Check className="w-4 h-4 text-green-600" /> : <Copy className="w-4 h-4" />}
             </button>

--- a/src/components/tools/JsonPrettyFormatter.tsx
+++ b/src/components/tools/JsonPrettyFormatter.tsx
@@ -1,11 +1,13 @@
 import React, { useState } from 'react';
 import { Copy, Check, RotateCcw } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 
 interface JsonPrettyFormatterProps {
   className?: string;
 }
 
 const JsonPrettyFormatter: React.FC<JsonPrettyFormatterProps> = ({ className = '' }) => {
+  const { t } = useTranslation();
   const [inputText, setInputText] = useState('');
   const [outputText, setOutputText] = useState('');
   const [copied, setCopied] = useState(false);

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -1,0 +1,33 @@
+import i18n from 'i18next';
+import { initReactI18next } from 'react-i18next';
+import LanguageDetector from 'i18next-browser-languagedetector';
+
+import ko from './locales/ko.json';
+import en from './locales/en.json';
+
+const resources = {
+  ko: {
+    translation: ko,
+  },
+  en: {
+    translation: en,
+  },
+};
+
+i18n
+  .use(LanguageDetector)
+  .use(initReactI18next)
+  .init({
+    resources,
+    fallbackLng: 'ko',
+    debug: process.env.NODE_ENV === 'development',
+    interpolation: {
+      escapeValue: false,
+    },
+    detection: {
+      order: ['localStorage', 'navigator', 'htmlTag'],
+      caches: ['localStorage'],
+    },
+  });
+
+export default i18n;

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1,0 +1,92 @@
+{
+  "common": {
+    "home": "Home",
+    "tools": "Tools",
+    "dashboard": "Dashboard",
+    "login": "Login",
+    "logout": "Logout",
+    "language": "Language",
+    "search": "Search",
+    "save": "Copy",
+    "cancel": "Cancel",
+    "delete": "Clear All",
+    "edit": "Edit",
+    "create": "Create",
+    "update": "Swap Input/Output",
+    "loading": "Loading...",
+    "error": "Error",
+    "success": "Success"
+  },
+  "header": {
+    "brand": "Baribari",
+    "navigation": {
+      "home": "Home",
+      "tools": "Tools",
+      "dashboard": "Dashboard"
+    },
+    "auth": {
+      "login": "Login",
+      "dashboard": "Dashboard"
+    }
+  },
+  "tools": {
+    "title": "Development Tools",
+    "description": "Various development tools are provided",
+    "search_placeholder": "Search tools...",
+    "categories": {
+      "all": "All",
+      "converter": "Converters",
+      "formatter": "Formatters",
+      "generator": "Generators",
+      "validator": "Validators"
+    },
+    "base64": {
+      "title": "Base64 Encoder/Decoder",
+      "description": "Encode or decode text to/from Base64",
+      "encode": "Encode",
+      "decode": "Decode",
+      "input_placeholder": "Enter text to encode/decode",
+      "output_placeholder": "Result will be displayed here"
+    },
+    "json": {
+      "title": "JSON Formatter",
+      "description": "Format JSON prettily or minify it",
+      "format": "Format",
+      "minify": "Minify",
+      "input_placeholder": "Enter JSON data",
+      "output_placeholder": "Formatted JSON will be displayed here"
+    },
+    "tools_list": {
+      "unit_converter": {
+        "name": "Unit Converter",
+        "description": "Convert various units such as length, weight, temperature, etc."
+      },
+      "json_formatter": {
+        "name": "JSON Formatter",
+        "description": "Format and minify JSON data beautifully."
+      },
+      "base64_converter": {
+        "name": "Base64 Converter",
+        "description": "Convert text and Base64 encoding mutually."
+      },
+      "timestamp_converter": {
+        "name": "Timestamp Converter",
+        "description": "Convert Unix timestamps and dates mutually."
+      }
+    }
+  },
+  "footer": {
+    "description": "A web utility hub that provides various conversion/tool functions. We provide convenient tools for developers and general users.",
+    "quick_links": "Quick Links",
+    "support": "Support",
+    "help": "Help",
+    "contact": "Contact Us",
+    "feedback": "Feedback",
+    "copyright": "© 2024 Baribari. Made by devgraft team.",
+    "links": {
+      "privacy": "Privacy Policy",
+      "terms": "Terms of Service",
+      "contact": "Contact Us"
+    }
+  }
+}

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -1,0 +1,92 @@
+{
+  "common": {
+    "home": "홈",
+    "tools": "도구",
+    "dashboard": "대시보드",
+    "login": "로그인",
+    "logout": "로그아웃",
+    "language": "언어",
+    "search": "검색",
+    "save": "복사",
+    "cancel": "취소",
+    "delete": "모두 지우기",
+    "edit": "편집",
+    "create": "생성",
+    "update": "입출력 바꾸기",
+    "loading": "로딩 중...",
+    "error": "오류",
+    "success": "성공"
+  },
+  "header": {
+    "brand": "바리바리",
+    "navigation": {
+      "home": "홈",
+      "tools": "도구",
+      "dashboard": "대시보드"
+    },
+    "auth": {
+      "login": "로그인",
+      "dashboard": "대시보드"
+    }
+  },
+  "tools": {
+    "title": "개발 도구",
+    "description": "다양한 개발 도구들을 제공합니다",
+    "search_placeholder": "도구 검색...",
+    "categories": {
+      "all": "전체",
+      "converter": "변환기",
+      "formatter": "포맷터",
+      "generator": "생성기",
+      "validator": "검증기"
+    },
+    "base64": {
+      "title": "Base64 인코더/디코더",
+      "description": "텍스트를 Base64로 인코딩하거나 디코딩합니다",
+      "encode": "인코딩",
+      "decode": "디코딩",
+      "input_placeholder": "인코딩/디코딩할 텍스트를 입력하세요",
+      "output_placeholder": "결과가 여기에 표시됩니다"
+    },
+    "json": {
+      "title": "JSON 포맷터",
+      "description": "JSON을 예쁘게 포맷팅하거나 압축합니다",
+      "format": "포맷",
+      "minify": "압축",
+      "input_placeholder": "JSON 데이터를 입력하세요",
+      "output_placeholder": "포맷된 JSON이 여기에 표시됩니다"
+    },
+    "tools_list": {
+      "unit_converter": {
+        "name": "단위 변환",
+        "description": "길이, 무게, 온도 등 다양한 단위를 변환할 수 있습니다."
+      },
+      "json_formatter": {
+        "name": "JSON 포맷터",
+        "description": "JSON 데이터를 보기 좋게 포맷팅하고 압축할 수 있습니다."
+      },
+      "base64_converter": {
+        "name": "Base64 변환",
+        "description": "텍스트와 Base64 인코딩을 상호 변환할 수 있습니다."
+      },
+      "timestamp_converter": {
+        "name": "타임스탬프 변환",
+        "description": "Unix 타임스탬프와 날짜를 상호 변환할 수 있습니다."
+      }
+    }
+  },
+  "footer": {
+    "description": "다양한 변환/도구 기능을 제공하는 웹 유틸리티 허브입니다. 개발자와 일반 사용자를 위한 편리한 도구들을 제공합니다.",
+    "quick_links": "빠른 링크",
+    "support": "지원",
+    "help": "도움말",
+    "contact": "문의하기",
+    "feedback": "피드백",
+    "copyright": "© 2024 바리바리. devgraft 팀에서 제작되었습니다.",
+    "links": {
+      "privacy": "개인정보처리방침",
+      "terms": "이용약관",
+      "contact": "문의하기"
+    }
+  }
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import App from './App.tsx';
 import './index.css';
+import './i18n';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>

--- a/src/pages/ToolsPage.tsx
+++ b/src/pages/ToolsPage.tsx
@@ -1,15 +1,17 @@
 import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
-import { Search, Filter, Zap, Code, Calculator, Clock, FileText, Shield } from 'lucide-react';
+import { Search, Zap, Code, Calculator, Clock, FileText, Shield } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 
 const ToolsPage: React.FC = () => {
+  const { t } = useTranslation();
   const [searchTerm, setSearchTerm] = useState('');
   const [selectedCategory, setSelectedCategory] = useState('all');
 
   const categories = [
-    { id: 'all', name: '전체', icon: Zap },
-    { id: 'converter', name: '변환기', icon: Calculator },
-    { id: 'formatter', name: '포맷터', icon: Code },
+    { id: 'all', name: t('tools.categories.all'), icon: Zap },
+    { id: 'converter', name: t('tools.categories.converter'), icon: Calculator },
+    { id: 'formatter', name: t('tools.categories.formatter'), icon: Code },
     { id: 'utility', name: '유틸리티', icon: FileText },
     { id: 'time', name: '시간/날짜', icon: Clock },
     { id: 'security', name: '보안', icon: Shield },
@@ -18,8 +20,8 @@ const ToolsPage: React.FC = () => {
   const tools = [
     {
       id: 'unit-converter',
-      name: '단위 변환',
-      description: '길이, 무게, 온도 등 다양한 단위를 변환할 수 있습니다.',
+      name: t('tools.tools_list.unit_converter.name'),
+      description: t('tools.tools_list.unit_converter.description'),
       category: 'converter',
       icon: Calculator,
       color: 'bg-blue-500',
@@ -27,8 +29,8 @@ const ToolsPage: React.FC = () => {
     },
     {
       id: 'json-pretty-formatter',
-      name: 'JSON 포맷터',
-      description: 'JSON 데이터를 보기 좋게 포맷팅하고 압축할 수 있습니다.',
+      name: t('tools.tools_list.json_formatter.name'),
+      description: t('tools.tools_list.json_formatter.description'),
       category: 'formatter',
       icon: Code,
       color: 'bg-green-500',
@@ -36,8 +38,8 @@ const ToolsPage: React.FC = () => {
     },
     {
       id: 'base64-converter',
-      name: 'Base64 변환',
-      description: '텍스트와 Base64 인코딩을 상호 변환할 수 있습니다.',
+      name: t('tools.tools_list.base64_converter.name'),
+      description: t('tools.tools_list.base64_converter.description'),
       category: 'security',
       icon: Shield,
       color: 'bg-purple-500',
@@ -45,8 +47,8 @@ const ToolsPage: React.FC = () => {
     },
     {
       id: 'timestamp-converter',
-      name: '타임스탬프 변환',
-      description: 'Unix 타임스탬프와 날짜를 상호 변환할 수 있습니다.',
+      name: t('tools.tools_list.timestamp_converter.name'),
+      description: t('tools.tools_list.timestamp_converter.description'),
       category: 'time',
       icon: Clock,
       color: 'bg-orange-500',
@@ -106,10 +108,10 @@ const ToolsPage: React.FC = () => {
         {/* Header */}
         <div className="text-center mb-12">
           <h1 className="text-4xl font-bold text-gray-900 mb-4">
-            모든 도구
+            {t('tools.title')}
           </h1>
           <p className="text-xl text-gray-600 max-w-2xl mx-auto">
-            개발과 일상에 필요한 다양한 웹 도구들을 찾아보세요
+            {t('tools.description')}
           </p>
         </div>
 
@@ -121,7 +123,7 @@ const ToolsPage: React.FC = () => {
               <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 w-5 h-5" />
               <input
                 type="text"
-                placeholder="도구 이름, 설명, 태그로 검색..."
+                placeholder={t('tools.search_placeholder')}
                 value={searchTerm}
                 onChange={(e) => setSearchTerm(e.target.value)}
                 className="input-field pl-10"


### PR DESCRIPTION
### What changes were proposed in this pull request?

- Integrated `i18next` and `react-i18next` for localization.
- Added support for English and Korean languages with initial translations.
- Created `LanguageSelector` component for switching languages.
- Updated `Header`, `Footer`, and `ToolsPage` to use localized strings.

Closes: #4 

### How was this patch tested?

